### PR TITLE
Modified mediafiles behaviour for prod environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache
 .env.dev
 .env.prod
 .env.prod.db
+/app/mediafiles*

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,14 +1,6 @@
-# syntax=docker/dockerfile:1
-
-# Comments are provided throughout this file to help you get started.
-# If you need more help, visit the Dockerfile reference guide at
-# https://docs.docker.com/go/dockerfile-reference/
-
-# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
-
 # Pull base image
-ARG PYTHON_VERSION=3.10.12
-FROM python:${PYTHON_VERSION}-slim as base
+ARG PYTHON_VERSION=3.11.4
+FROM python:${PYTHON_VERSION}-slim-buster as base
 
 # Prevents Python from writing pyc files.
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -19,7 +11,8 @@ ENV PYTHONUNBUFFERED=1
 
 # Install system dependencies
 # netcat used to check status of database
-RUN apt-get update && apt-get install -y netcat-traditional
+RUN apt-get update && \ 
+    apt-get install -y netcat-traditional
 
 # Set working directory
 WORKDIR /usr/src/app
@@ -40,6 +33,9 @@ RUN chmod +x /usr/src/app/entrypoint.sh
 # Copy the source code into the container.
 COPY . .
 
+# run entrypoint.sh
+ENTRYPOINT ["/usr/src/app/entrypoint.sh"]
+
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/go/dockerfile-user-best-practices/
 # ARG UID=10001
@@ -54,7 +50,3 @@ COPY . .
 
 # Switch to the non-privileged user to run the application.
 # USER appuser
-
-
-# run entrypoint.sh
-ENTRYPOINT ["/usr/src/app/entrypoint.sh"]

--- a/app/hello_django/settings.py
+++ b/app/hello_django/settings.py
@@ -129,7 +129,13 @@ STATIC_URL = '/static/'
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 MEDIA_URL = "/media/"
-MEDIA_ROOT = BASE_DIR / "mediafiles"
+
+# if in production env (DEBUG = Tur), save files to /usr/mediafiles
+# usr/mediafiles is mounted to a Docker volume
+# else, mediafiles directory is created in host machine, since the
+# /usr/src/app directory in the container is mounted to the host's
+# ./app directory, and mediafiles are save in /usr/src/app/mediafiles
+MEDIA_ROOT = "/usr/mediafiles" if DEBUG else BASE_DIR / "mediafiles"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field

--- a/app/upload/views.py
+++ b/app/upload/views.py
@@ -5,6 +5,7 @@ from django.core.files.storage import FileSystemStorage
 def image_upload(request):
     if request.method == "POST" and request.FILES["image_file"]:
         image_file = request.FILES["image_file"]
+        # by default files are saved in path specified by MEDIA_ROOT
         fs = FileSystemStorage()
         filename = fs.save(image_file.name, image_file)
         image_url = fs.url(filename)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:
       - ./app/:/usr/src/app/
+      - media_volume:/usr/mediafiles
     ports:
       - 8000:8000
     env_file:
@@ -22,3 +23,4 @@ services:
 
 volumes:
   postgres_data:
+  media_volume:


### PR DESCRIPTION
Previously, images uploaded were save to the '/usr/src/app/mediafiles/' directory. Since '/usr/src/app/' was mounted to the './app' directory in the host FS, starting and using the prod environment would create a directory (owned by root) in the host FS.

New behaviour: Images are now saved to '/usr/mediafiles/' directory which is mounted to a Docker volume. Launching and using the prod environment will no longer cause side effects in the host FS and media can persist in volume.
